### PR TITLE
chore(renovate): pin react packages to v18

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,6 +8,16 @@
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "platformAutomerge": true
+    },
+    {
+      "allowedVersions": "<19",
+      "description": "Gatsby.js が React 19 に未対応のため v18 系に固定する",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 概要

Gatsby.js が React 19 に未対応のため、Renovate が react monorepo を v19 へメジャーアップデートしようとする PR (#381) を抑止します。

## 変更内容

`.renovaterc.json` に packageRule を追加し、以下のパッケージを v19 未満に固定:

- `react`
- `react-dom`
- `@types/react`
- `@types/react-dom`

`allowedVersions: "<19"` を使用しているため、v18 系の minor/patch アップデートは引き続き提案されます。

## 補足

- このリポジトリの react 関連依存はこの4パッケージのみのため、Renovate の react monorepo グループ (#381 の対象) と過不足なく一致します。
- Gatsby が React 19 に対応した際は、このルールを削除してください。
- 既存の #381 は手動でクローズが必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)