### PR TITLE
chore(renovate): pin babel to v7 and typescript to v6

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -18,6 +18,16 @@
         "@types/react",
         "@types/react-dom"
       ]
+    },
+    {
+      "allowedVersions": "<8",
+      "description": "babel-preset-gatsby-package が Babel 8 に未対応のため v7 系に固定する",
+      "matchPackageNames": ["@babel*"]
+    },
+    {
+      "allowedVersions": "<7",
+      "description": "ts-jest と @typescript-eslint が TypeScript 7 に未対応のため v6 系に固定する",
+      "matchPackageNames": ["typescript"]
     }
   ]
 }


### PR DESCRIPTION
## 概要

Babel 8 (#392) と TypeScript 7 (#396) はいずれも現時点で採用できないため、Renovate 側で固定します。React 19 の固定と同じ方針です。

## 理由

### Babel v7 に固定

`babel-preset-gatsby-package@3.16.0`（最新）の peer dependency が `@babel/core: ^7.11.6` で、依存パッケージも全て `^7.x` です。Babel 8 に上げると `yarn build` が以下で失敗します。

```
Error: [BABEL] Requires Babel "^7.0.0-0", but was loaded with "8.0.1".
```

Gatsby 本体側が Babel 8 に対応するまで解除できません。

### TypeScript v6 に固定

TypeScript 7 はネイティブ移植版で、従来の JavaScript コンパイラ API が削除されました。これに依存しているツールが動作しません。

| パッケージ | 最新版 | peer 範囲 | 症状 |
| --- | --- | --- | --- |
| `ts-jest` | 29.4.12 | `>=4.3 <7` | `TypeError: Cannot read properties of undefined (reading 'fileExists')` |
| `@typescript-eslint/typescript-estree` | 8.66.0 | `>=4.8.4 <6.1.0` | `TypeError: Cannot read properties of undefined (reading 'Cjs')` |

上流はいずれも「programmatic API が安定する TypeScript 7.1 待ち」の状態です。

## 検証

- `npx renovate-config-validator .renovaterc.json` → `Config validated successfully`
- `yarn format --check` → pass

## 備考

バリデータが `WARN: Config migration necessary` を出しますが、これは既存の 1 つ目のルールが使っている `matchPackagePatterns`（Renovate で非推奨、現在は `matchPackageNames` が glob を受け付ける）が原因です。本 PR のスコープ外のため変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzqFT9KyMTNcShpzAy1PZN
